### PR TITLE
구글 스프레드시트 연동 및 데이터 불러오기 기능 구성 및 검증

### DIFF
--- a/src/main/kotlin/kr/or/dohands/dozon/sheet/config/GoogleSheetsConfiguration.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/sheet/config/GoogleSheetsConfiguration.kt
@@ -1,0 +1,20 @@
+package kr.or.dohands.dozon.sheet.config
+
+import kr.or.dohands.dozon.sheet.service.GoogleSheetsService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GoogleSheetsConfiguration {
+
+    @Value("\${credentialPath}") private lateinit var credentialPath:String
+    @Value("\${email}") private lateinit var email: String
+    @Value("\${applicationName}") private lateinit var applicationName: String
+    @Value("\${sheetId}") private lateinit var sheetId: String
+
+    @Bean
+    fun googleSheetsService(): GoogleSheetsService {
+        return GoogleSheetsService(credentialPath, email, applicationName, sheetId)
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/sheet/service/GoogleSheetsService.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/sheet/service/GoogleSheetsService.kt
@@ -1,0 +1,76 @@
+package kr.or.dohands.dozon.sheet.service
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.SheetsScopes
+import com.google.api.services.sheets.v4.model.ValueRange
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.auth.oauth2.ServiceAccountCredentials
+import java.io.FileInputStream
+
+
+class GoogleSheetsService(
+    private val credentialPath:String,
+    private val email: String,
+    private val applicationName: String,
+    private val sheetId: String
+) {
+    private var sheets: Sheets? = null
+
+//    init {
+//        println("!!! ${credentialPath}")
+//        println("!!! ${email}")
+//        println("!!! ${applicationName}")
+//        println("!!! ${sheetId}")
+//    }
+
+    fun getSheetsService(): Sheets {
+        if (sheets == null) {
+            sheets = initializeSheets()
+        }
+        return sheets!!
+    }
+
+
+    private fun initializeSheets(): Sheets {
+        var credentials = GoogleCredentials
+            .fromStream(FileInputStream(credentialPath))
+            .createScoped(listOf(SheetsScopes.SPREADSHEETS))
+        return Sheets(
+            com.google.api.client.http.javanet.NetHttpTransport(),
+            JacksonFactory.getDefaultInstance(),
+            HttpCredentialsAdapter(credentials)
+        )
+    }
+
+
+    fun loadCredentials(): GoogleCredentials {
+        return GoogleCredentials
+            .fromStream(FileInputStream(credentialPath))
+            .createScoped(listOf(SheetsScopes.SPREADSHEETS))
+    }
+
+    fun getValue(sheetName:String, cellRange:String): ValueRange {
+        return getSheets()
+            .spreadsheets()
+            .values()
+            .get(sheetId, "${sheetName.trim()}!${cellRange.trim()}")
+            .execute()
+    }
+
+    private fun getSheets(): Sheets {
+        return Sheets.Builder(
+            GoogleNetHttpTransport.newTrustedTransport(),
+            GsonFactory.getDefaultInstance(),
+            HttpCredentialsAdapter(
+                ServiceAccountCredentials.fromStream(FileInputStream(credentialPath))
+                    .createScoped(listOf(SheetsScopes.SPREADSHEETS))
+                    .createDelegated(email)
+            )
+        ).setApplicationName(applicationName).build()
+    }
+
+}

--- a/src/test/kotlin/kr/or/dohands/dozon/service/GoogleSheetsTest.kt
+++ b/src/test/kotlin/kr/or/dohands/dozon/service/GoogleSheetsTest.kt
@@ -1,0 +1,67 @@
+package kr.or.dohands.dozon.service
+
+import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.model.ValueRange
+import com.google.auth.oauth2.GoogleCredentials
+import kr.or.dohands.dozon.sheet.config.GoogleSheetsConfiguration
+import kr.or.dohands.dozon.sheet.service.GoogleSheetsService
+import org.assertj.core.api.Assertions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.test.Test
+
+@SpringBootTest(
+    classes = [GoogleSheetsConfiguration::class]
+)
+class GoogleSheetsTest @Autowired constructor(
+    private val googleSheetsService: GoogleSheetsService,
+) {
+    @Test
+    fun `시트 연동을 시도한다` () {
+
+        var result : Sheets  = googleSheetsService.getSheetsService()
+        Assertions.assertThat(result).isNotNull()
+        Assertions.assertThat(result.spreadsheets()).isNotNull()
+    }
+
+    @Test
+    fun `credential이 정상인지 확인한다` () {
+
+        var result: GoogleCredentials = googleSheetsService.loadCredentials()
+        Assertions.assertThat(result).isNotNull()
+        Assertions.assertThat(result.createScoped()).isNotNull()
+    }
+
+    @Test
+    fun `경험치 현황 셀 데이터를 로드한다` () {
+
+        val value: ValueRange = googleSheetsService.getValue("경험치 현황", "B13:G14")
+        Assertions.assertThat(value).isNotNull()
+        println(value.getValues())
+    }
+
+    @Test
+    fun `인사평가 셀 데이터를 로드한다` () {
+
+        val value = googleSheetsService.getValue("인사평가", "H10:K34")
+        Assertions.assertThat(value).isNotNull()
+        println(value.getValues())
+    }
+
+    // J13:S378
+    @Test
+    fun `직무별 퀘스트 셀 데이터를 로드한다` () {
+
+        val value: ValueRange = googleSheetsService.getValue("직무별 퀘스트", "J13:S378")
+
+        //[월, 주, 날짜, 요일, 매출, 인건비, 설계용역비, 직원급여, 퇴직급여, 4대보험료],
+        //[1, 1, 25-1-1, Wed, 10, 4, 1, 1, 1, 1]
+
+        Assertions.assertThat(value).isNotNull()
+//        Assertions.assertThat(value.getValues().size).isEqualTo(365)
+        println(value.getValues().size)
+//        Assertions.assertThat(value.getValues().indexOf(value.getValues().size))
+        println(value.getValues().get(value.getValues().lastIndex))
+    }
+
+}


### PR DESCRIPTION
구글 스프레드시트 API 연동을 시도하는 테스트를 작성하며 Service 로직을 구성하였고,
간단히 경험치 현황, 인사평가, 직무별 퀘스트 셀 데이터를 로드해보는 테스트를 작성하며 Service 로직을 리팩토링하였습니다.

Configuration 클래스가 Service 클래스의 보호해야할 Value 데이터와 Bean 등록 역할을 가져갔고,
Service 클래스는 스프레드시트 연동 및 데이터 불러오기 역할만 맡게 되었습니다.

 