### PR TITLE
feat: expo 푸시알림 기능 구성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     id("org.springframework.boot") version "3.3.7"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
+    id("org.unbroken-dome.test-sets") version "4.1.0" // 테스트 세트 플러그인
+    id("maven-publish")
+    id("signing")
 }
 
 group = "kr.or.dohands"
@@ -13,38 +16,67 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom(configurations.annotationProcessor.get())
-    }
+    withJavadocJar()
+    withSourcesJar()
 }
 
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 
+dependencies {
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // Jackson
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.15.2")
+
+    // Google API
     implementation("com.google.api-client:google-api-client:1.34.1")
     implementation("com.google.auth:google-auth-library-oauth2-http:1.17.0")
     implementation("com.google.apis:google-api-services-sheets:v4-rev612-1.25.0")
     implementation("com.google.http-client:google-http-client-jackson2:1.41.0")
+    implementation("com.google.apis:google-api-services-drive:v3-rev136-1.25.0")
 
+    // HTTP Client
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 
-    compileOnly("org.projectlombok:lombok")
+    // Logging
+    implementation("org.slf4j:slf4j-api:2.0.9")
+    implementation("org.slf4j:jcl-over-slf4j:2.0.9")
+
+    // Commons Lang
+    implementation("org.apache.commons:commons-lang3:3.13.0")
+
+    // JWT
+    implementation("com.auth0:java-jwt:4.4.0")
+
+    // OpenAPI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+
+    // Database
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+
+    // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.kotest:kotest-runner-junit5:5.7.2")
+    testImplementation("io.kotest:kotest-framework-api:5.7.2")
+    testImplementation("org.mock-server:mockserver-junit-jupiter:5.15.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Integration Test
+//    integrationTestImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+//    integrationTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }
 
 kotlin {
@@ -59,6 +91,84 @@ allOpen {
     annotation("jakarta.persistence.Embeddable")
 }
 
+testSets {
+    create("integrationTest")
+}
+
 tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "ossrh"
+            val releaseRepoUrl = project.findProperty("ossrhReleaseRepoUrl") as String? ?: ""
+            val snapshotRepoUrl = project.findProperty("ossrhSnapshotRepoUrl") as String? ?: ""
+            url = if (isReleaseVersion) uri(releaseRepoUrl) else uri(snapshotRepoUrl)
+
+            credentials {
+                username = project.findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME") ?: ""
+                password = project.findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD") ?: ""
+            }
+        }
+
+        maven {
+            name = "nexus"
+            val releaseRepoUrl = project.findProperty("nexusReleaseRepoUrl") as String? ?: ""
+            val snapshotRepoUrl = project.findProperty("nexusSnapshotRepoUrl") as String? ?: ""
+            url = if (isReleaseVersion) uri(releaseRepoUrl) else uri(snapshotRepoUrl)
+
+            credentials {
+                username = project.findProperty("nexusUsername") as String? ?: System.getenv("NEXUS_USERNAME") ?: ""
+                password = project.findProperty("nexusPassword") as String? ?: System.getenv("NEXUS_PASSWORD") ?: ""
+            }
+        }
+    }
+
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+
+            pom {
+                name.set("expo-server-sdk")
+                description.set("Java implementation of expo-server-sdk implementation. Classes and methods to manage push notifications")
+                url.set("https://github.com/nia-medtech/expo-server-sdk-java")
+
+                licenses {
+                    license {
+                        name.set("The MIT License")
+                        url.set("https://raw.githubusercontent.com/nia-medtech/expo-server-sdk-java/edit/main/LICENCE.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("oliverwelter")
+                        name.set("Oliver Welter")
+                        email.set("oliver.welter@nia-medtech.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git@github.com:nia-medtech/expo-server-sdk-java.git")
+                    developerConnection.set("scm:git:git@github.com:nia-medtech/expo-server-sdk-java.git")
+                    url.set("https://github.com/nia-medtech/expo-server-sdk-java")
+                }
+            }
+        }
+    }
+}
+
+
+signing {
+    isRequired = isReleaseVersion && gradle.taskGraph.hasTask("publish")
+    useInMemoryPgpKeys(
+        project.findProperty("signingKey") as String?,
+        project.findProperty("signingPassword") as String?
+    )
+    sign(publishing.publications["mavenJava"])
+}
+
+
+tasks.named<Test>("integrationTest") {
     useJUnitPlatform()
 }

--- a/src/main/kotlin/kr/or/dohands/dozon/core/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/core/exception/ExceptionHandler.kt
@@ -1,0 +1,19 @@
+package kr.or.dohands.dozon.core.exception
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import kr.or.dohands.dozon.core.response.Response
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ExceptionHandler {
+    @ExceptionHandler(value = [IllegalArgumentException::class, IllegalStateException::class])
+    protected fun handleIllegalException(e: IllegalArgumentException): Response<String> {
+        return Response(401, "", e.message.toString())
+    }
+
+    @ExceptionHandler(value = [MismatchedInputException::class])
+    protected fun handleMisMatchedInputExceptionIgnore(e: MismatchedInputException): Response<String> {
+        return Response(200, "", "메시지 전송 성공")
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/ExpoPushNotificationClient.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/ExpoPushNotificationClient.kt
@@ -1,0 +1,87 @@
+package com.niamedtech.expo.exposerversdk
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import kr.or.dohands.dozon.notification.handler.BaseResponseHandler
+import kr.or.dohands.dozon.notification.request.PushNotification
+import kr.or.dohands.dozon.notification.request.ReceiptRequest
+import kr.or.dohands.dozon.notification.response.ReceiptResponse
+import kr.or.dohands.dozon.notification.response.TicketResponse
+import kr.or.dohands.dozon.notification.util.ObjectMapperFactory
+import org.apache.hc.client5.http.classic.methods.HttpPost
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.core5.http.io.entity.StringEntity
+import java.io.IOException
+import java.net.URI
+
+/**
+ * Client for synchronous communication with Expo Push Notification Service.
+ * See https://docs.expo.dev/push-notifications/sending-notifications/
+ */
+class ExpoPushNotificationClient private constructor(
+    private val baseUri: URI,
+    private val httpClient: CloseableHttpClient
+) {
+
+    private val objectMapper: ObjectMapper = ObjectMapperFactory().getInstance()
+
+    private val sendResponseHandler =
+        BaseResponseHandler(TicketResponse::class.java)
+
+    private val getReceiptHandler =
+        BaseResponseHandler(ReceiptResponse::class.java)
+
+    @Throws(IOException::class)
+    fun sendPushNotifications(notifications: List<PushNotification>): List<TicketResponse.Ticket> {
+        val request = createHttpPostRequest("/push/send", notifications)
+        return httpClient.execute(request, sendResponseHandler)
+    }
+
+    @Throws(JsonProcessingException::class)
+    private fun createHttpPostRequest(subpath: String, requestData: Any): HttpPost {
+        val request = HttpPost(URI.create(baseUri.toString() + subpath))
+        request.setHeader("Host", "exp.host")
+        request.setHeader("accept", "application/json")
+        request.setHeader("accept-encoding", "gzip, deflate")
+        request.setHeader("content-type", "application/json")
+
+        val json = objectMapper.writeValueAsString(requestData)
+        val stringEntity = StringEntity(json)
+        request.entity = stringEntity
+
+        return request
+    }
+
+    @Throws(IOException::class)
+    fun getPushNotificationReceipts(ids: List<String>): Map<String, ReceiptResponse.Receipt> {
+        val request = createHttpPostRequest("/push/getReceipts", ReceiptRequest(ids))
+        return httpClient.execute(request, getReceiptHandler)
+    }
+
+    class Builder {
+        private var baseUri: String = "https://exp.host/--/api/v2/"
+        private var httpClient: CloseableHttpClient? = null
+
+        fun setBaseUri(baseUri: String): Builder {
+            this.baseUri = baseUri
+            return this
+        }
+
+        fun setHttpClient(httpClient: CloseableHttpClient): Builder {
+            this.httpClient = httpClient
+            return this
+        }
+
+        fun build(): ExpoPushNotificationClient {
+            val client = httpClient
+                ?: throw IllegalArgumentException("HttpClient must be provided")
+            return ExpoPushNotificationClient(URI.create(baseUri), client)
+        }
+    }
+
+    companion object {
+        fun builder(): Builder {
+            return Builder()
+        }
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/controller/NotificationController.kt
@@ -1,0 +1,24 @@
+package kr.or.dohands.dozon.notification.controller
+
+import kr.or.dohands.dozon.notification.request.NotificationRequest
+import kr.or.dohands.dozon.notification.service.NotificationService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/notification")
+class NotificationController(
+    private val notificationService: NotificationService
+) {
+
+    @PostMapping("/send")
+    fun push(
+        @RequestParam type : String, @RequestParam questId : String
+    ): Unit {
+        notificationService.push()
+    }
+
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/exception/ErrorResponseException.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/exception/ErrorResponseException.kt
@@ -1,0 +1,27 @@
+package kr.or.dohands.dozon.notification.exception
+
+import kr.or.dohands.dozon.notification.response.BaseResponse
+
+class ErrorResponseException(
+    code: Int,
+    phrase: String,
+    errors: List<BaseResponse.Error>
+) : Exception(createMessage(code, phrase, errors)) {
+
+    companion object{
+        private fun createMessage(code: Int, phrase: String, errors: List<BaseResponse.Error>): String {
+            val sb : StringBuilder = StringBuilder()
+            sb.append(String.format("Return code: %d%n", code))
+            sb.append(String.format("Phrase: %s%n", phrase))
+            sb.append(String.format("Errors: %n", errors))
+            if (errors != null && errors.isEmpty()){
+                for (error in errors){
+                    sb.append(String.format("%s%n", error.toString()))
+                }
+            } else {
+                sb.append("")
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/handler/BaseResponseHandler.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/handler/BaseResponseHandler.kt
@@ -1,0 +1,49 @@
+package kr.or.dohands.dozon.notification.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kr.or.dohands.dozon.notification.exception.ErrorResponseException
+import kr.or.dohands.dozon.notification.response.BaseResponse
+import lombok.AllArgsConstructor
+import lombok.extern.slf4j.Slf4j
+import org.apache.hc.core5.http.ClassicHttpResponse
+import org.apache.hc.core5.http.HttpException
+import org.apache.hc.core5.http.io.HttpClientResponseHandler
+import org.apache.hc.core5.http.io.entity.EntityUtils
+import java.io.IOException
+import kotlin.jvm.Throws
+
+@Slf4j
+@AllArgsConstructor
+class BaseResponseHandler<T>(
+    private val responseClass: Class<out BaseResponse<T>>
+): HttpClientResponseHandler<T> {
+
+    companion object{
+        private val OBJECT_MAPPER = ObjectMapper()
+    }
+
+    @Throws(IOException::class, HttpException::class)
+    private fun processResponse(httpResponse: ClassicHttpResponse) : BaseResponse<T>{
+        val entity = httpResponse.entity ?: throw HttpException("Entity is null")
+        val content = EntityUtils.toString(entity)
+        println("Received Content: $content")
+        return OBJECT_MAPPER.readValue(content, responseClass)
+    }
+
+    @Throws(IOException::class, IOException::class)
+    override fun handleResponse(httpResponse: ClassicHttpResponse): T {
+        val response = processResponse(httpResponse)
+        if (httpResponse.code == 200) {
+            return response.data
+        }
+
+        throw HttpException(
+            "Response with errors",
+            ErrorResponseException(
+                httpResponse.code,
+                httpResponse.reasonPhrase,
+                response.errors
+            )
+        )
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/request/PushNotification.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/request/PushNotification.kt
@@ -1,0 +1,59 @@
+package kr.or.dohands.dozon.notification.request
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import lombok.AllArgsConstructor
+import lombok.Data
+import lombok.NonNull
+
+@Data
+@AllArgsConstructor
+data class PushNotification(
+    var to: List<String> = listOf(),
+    var data: Map<String, Any>? = null,
+    var title: String? = null,
+    var subtitle: String? = null,
+    var body: String? = null,
+    var sound: Sound? = null,
+    var ttl: Long? = null,
+    var expiration: Long? = null,
+    var priority: Priority? = null,
+    var badge: Long? = null,
+    var channelId: String? = null
+) {
+    constructor(other: PushNotification) : this(
+        to = other.to,
+        data = other.data,
+        title = other.title,
+        subtitle = other.subtitle,
+        body = other.body,
+        sound = other.sound?.copy(),
+        ttl = other.ttl,
+        expiration = other.expiration,
+        priority = other.priority,
+        badge = other.badge,
+        channelId = other.channelId
+    )
+
+    enum class Priority {
+        @JsonProperty("default")
+        OK,
+
+        @JsonProperty("high")
+        ERROR,
+
+        @JsonProperty("normal")
+        NORMAL
+    }
+
+    @Data
+    data class Sound(
+        var critical: Boolean? = null,
+        var name: String? = null,
+        var volume: Long? = null
+    ) {
+        fun copy(): Sound {
+            return Sound(critical, name, volume)
+        }
+    }
+}
+

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/request/ReceiptRequest.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/request/ReceiptRequest.kt
@@ -1,0 +1,11 @@
+package kr.or.dohands.dozon.notification.request
+
+import lombok.AllArgsConstructor
+import lombok.Data
+import lombok.NonNull
+
+@Data
+@AllArgsConstructor
+data class ReceiptRequest(
+    @NonNull val ids: List<String>
+)

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/response/BaseResponse.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/response/BaseResponse.kt
@@ -1,0 +1,40 @@
+package kr.or.dohands.dozon.notification.response
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.databind.JsonNode
+import lombok.Data
+import lombok.EqualsAndHashCode
+
+/**
+ * Base class for responses provided by Expo Push Notification Service.
+ */
+@Data
+abstract class BaseResponse<T> {
+
+    abstract val data: T
+
+    var errors: List<Error> = emptyList()
+
+    open class GenericData {
+        /**
+         * Store unmapped data in case actual response is varying from specification.
+         */
+        private val any: MutableMap<String, JsonNode> = mutableMapOf()
+
+        @JsonAnyGetter
+        fun getAny(): Map<String, JsonNode> = any
+
+        @JsonAnySetter
+        fun addAny(key: String, value: JsonNode) {
+            any[key] = value
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    data class Error(
+        var code: String? = null,
+        var message: String? = null
+    ) : GenericData()
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/response/ReceiptResponse.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/response/ReceiptResponse.kt
@@ -1,0 +1,51 @@
+package kr.or.dohands.dozon.notification.response
+
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import lombok.Data
+import lombok.EqualsAndHashCode
+
+/**
+ * Response including receipts for tickets.
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+data class ReceiptResponse(
+    override val data: Map<String, Receipt>
+) : BaseResponse<Map<String, ReceiptResponse.Receipt>>() {
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    data class Receipt(
+        var status: Status? = null,
+        var message: String? = null,
+        var details: Details? = null
+    ) : GenericData() {
+
+        @Data
+        data class Details(
+            var error: Error? = null,
+            var sentAt: Int? = null,
+            var errorCodeEnum: String? = null,
+            var additionalProperties: JsonNode? = null
+        ) {
+            enum class Error {
+                @JsonProperty("DeviceNotRegistered")
+                DEVICE_NOT_REGISTERED,
+
+                @JsonProperty("MessageTooBig")
+                MESSAGE_TOO_BIG,
+
+                @JsonProperty("MessageRateExceeded")
+                MESSAGE_RATE_EXCEEDED,
+
+                @JsonProperty("InvalidCredentials")
+                INVALID_CREDENTIALS,
+
+                @JsonProperty("InvalidProviderToken")
+                INVALID_PROVIDERTOKEN
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/response/Status.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/response/Status.kt
@@ -1,0 +1,11 @@
+package kr.or.dohands.dozon.notification.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class Status {
+    @JsonProperty("ok")
+    OK,
+
+    @JsonProperty("error")
+    ERROR
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/response/TicketResponse.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/response/TicketResponse.kt
@@ -1,0 +1,53 @@
+package kr.or.dohands.dozon.notification.response
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import lombok.Data
+import lombok.EqualsAndHashCode
+
+/**
+ * Response including tickets for push notifications.
+ */
+//@Data
+//@EqualsAndHashCode(callSuper = false)
+class TicketResponse @JsonCreator constructor(
+    override val data: List<Ticket>
+) : BaseResponse<List<TicketResponse.Ticket>>() {
+
+
+//    @Data
+//    @EqualsAndHashCode(callSuper = false)
+    class Ticket (
+        @JsonProperty("status")
+        var status: String,
+        @JsonProperty("id")
+        var id: String,
+        @JsonProperty("message")
+        var message: String,
+        @JsonProperty("details")
+        var details: Details
+    ) : GenericData() {
+
+        enum class Error {
+            @JsonProperty("DeviceNotRegistered")
+            DEVICE_NOT_REGISTERED,
+
+            @JsonProperty("InvalidCredentials")
+            INVALID_CREDENTIALS
+        }
+
+        @Data
+        class Details(
+            @JsonProperty("error")
+            var error: Error? = null,
+            @JsonProperty("sentAt")
+            var sentAt: Int? = null,
+            @JsonProperty("additionalProperties")
+            var additionalProperties: JsonNode? = null
+        )
+    }
+}
+
+

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/service/Notification.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/service/Notification.kt
@@ -1,0 +1,5 @@
+package kr.or.dohands.dozon.notification.service
+
+interface Notification {
+    fun push()
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/service/NotificationService.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/service/NotificationService.kt
@@ -1,0 +1,50 @@
+package kr.or.dohands.dozon.notification.service
+
+import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient
+import kr.or.dohands.dozon.notification.request.PushNotification
+import kr.or.dohands.dozon.notification.response.ReceiptResponse
+import kr.or.dohands.dozon.notification.response.TicketResponse
+import lombok.extern.slf4j.Slf4j
+import org.apache.hc.client5.http.classic.methods.HttpPost
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.springframework.stereotype.Service
+import kotlin.math.log
+
+@Slf4j
+@Service
+class NotificationService(
+
+): Notification {
+     private val host = ExpoPushNotificationClient.builder()
+         .setHttpClient(HttpClients.createDefault())
+         .build()
+
+    override fun push() {
+        expoPushNotification()
+    }
+
+    private fun expoPushNotification() {
+
+        // token 검색 필요
+        val token: String = "ExponentPushToken[Rvbx83G_XYcHdRIo70DG_K]"
+        val token2: String =  "ExponentPushToken[ig62iLPv3vHGnrZIORdxUN]"
+
+        // 메시지 내용 및 토큰 입력
+        val expoPushNotification = PushNotification().apply{
+            to = listOf(token, token2)
+            title = "안녕하세요 정규환님"
+            body = "퀘스트가 완료되었습니다. 확인해보세요!"
+        }
+
+        host.sendPushNotifications(listOf(expoPushNotification))
+
+    }
+
+
+    // username 님
+    //  ~ 퀘스트 완료되었습니다! 지금 확인해보세요!
+
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/util/ObjectMapperFactory.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/util/ObjectMapperFactory.kt
@@ -1,0 +1,30 @@
+package kr.or.dohands.dozon.notification.util
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+
+
+class ObjectMapperFactory {
+
+    private val OBJECT_MAPPER = createObjectMapper()
+
+    private fun createObjectMapper(): ObjectMapper {
+        val objectMapper = ObjectMapper()
+//        val objectMapper = ObjectMapper().registerModule(
+//            KotlinModule.Builder().build()
+//        )
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        return objectMapper
+    }
+
+    private object ObjectMapperFactory {
+        init {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    fun getInstance(): ObjectMapper {
+        return OBJECT_MAPPER
+    }
+}

--- a/src/main/kotlin/kr/or/dohands/dozon/notification/util/PushNotificationUtil.kt
+++ b/src/main/kotlin/kr/or/dohands/dozon/notification/util/PushNotificationUtil.kt
@@ -1,0 +1,88 @@
+package kr.or.dohands.dozon.notification.util
+
+import kr.or.dohands.dozon.notification.request.PushNotification
+
+
+object PushNotificationUtil {
+
+    private const val PUSH_NOTIFICATION_CHUNK_LIMIT = 100
+    private const val PUSH_NOTIFICATION_RECEIPT_CHUNK_LIMIT = 300
+
+    fun isExponentPushToken(token: String): Boolean {
+        val prefixA = "ExponentPushToken["
+        val prefixB = "ExpoPushToken["
+        val postfix = "]"
+        val regex = "[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}"
+
+        if (token.matches(regex.toRegex())) {
+            return true
+        }
+
+        if (!token.endsWith(postfix)) {
+            return false
+        }
+
+        return token.startsWith(prefixA) || token.startsWith(prefixB)
+    }
+
+    fun chunkPushNotificationReceiptIds(receiptIds: List<String>): List<List<String>> {
+        return chunkItems(receiptIds, PUSH_NOTIFICATION_RECEIPT_CHUNK_LIMIT)
+    }
+
+    fun <T> chunkItems(items: List<T>, chunkSize: Int): List<List<T>> {
+        val chunks = mutableListOf<List<T>>()
+        var chunk = mutableListOf<T>()
+        for (item in items) {
+            chunk.add(item)
+            if (chunk.size >= chunkSize) {
+                chunks.add(chunk)
+                chunk = mutableListOf()
+            }
+        }
+
+        if (chunk.isNotEmpty()) {
+            chunks.add(chunk)
+        }
+        return chunks
+    }
+
+    fun chunkPushNotifications(messages: List<PushNotification>): List<List<PushNotification>> {
+        val chunks = mutableListOf<List<PushNotification>>()
+        var chunk = mutableListOf<PushNotification>()
+
+        var chunkMessagesCount = 0
+        for (message in messages) {
+            var partialTo = mutableListOf<String>()
+            for (recipient in message.to) {
+                if (recipient.isEmpty()) continue
+                partialTo.add(recipient)
+                chunkMessagesCount++
+                if (chunkMessagesCount >= PUSH_NOTIFICATION_CHUNK_LIMIT) {
+                    val tmpCopy = message.copy(to = partialTo)
+                    chunk.add(tmpCopy)
+                    chunks.add(chunk)
+                    chunk = mutableListOf()
+                    chunkMessagesCount = 0
+                    partialTo = mutableListOf()
+                }
+            }
+
+            if (partialTo.isNotEmpty()) {
+                val tmpCopy = message.copy(to = partialTo)
+                chunk.add(tmpCopy)
+            }
+
+            if (chunkMessagesCount >= PUSH_NOTIFICATION_CHUNK_LIMIT) {
+                chunks.add(chunk)
+                chunk = mutableListOf()
+                chunkMessagesCount = 0
+            }
+        }
+
+        if (chunkMessagesCount > 0) {
+            chunks.add(chunk)
+        }
+
+        return chunks
+    }
+}

--- a/src/test/kotlin/kr/or/dohands/dozon/notification/NotificationTest.kt
+++ b/src/test/kotlin/kr/or/dohands/dozon/notification/NotificationTest.kt
@@ -1,0 +1,78 @@
+package kr.or.dohands.dozon.notification
+
+import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient
+import kr.or.dohands.dozon.notification.request.PushNotification
+import kr.or.dohands.dozon.notification.response.ReceiptResponse
+import kr.or.dohands.dozon.notification.response.TicketResponse
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.junit.jupiter.MockServerExtension
+import org.mockserver.matchers.Times
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpResponse
+import kotlin.test.Test
+
+@ExtendWith(MockServerExtension::class)
+class NotificationTest(
+
+) {
+
+    companion object{
+        private val EXPO_NOTIFICATION_TOKEN = "ExponentPushToken[Rvbx83G_XYcHdRIo70DG_K]"
+        private val EXPO_NOTIFICATION_TOKEN_2 = "ExponentPushToken[ig62iLPv3vHGnrZIORdxUN]"
+    }
+
+    private lateinit var client: ClientAndServer
+    private lateinit var httpClient: CloseableHttpClient
+    private lateinit var testee: ExpoPushNotificationClient
+
+    @BeforeEach
+    fun setUp(client: ClientAndServer) {
+        this.client = client
+        httpClient = HttpClients.createDefault()
+
+        testee = ExpoPushNotificationClient.builder()
+//            .setBaseUri("http://localhost" + client.localPort)
+            .setHttpClient(httpClient)
+            .build()
+    }
+
+
+    @Test
+    fun `알림을 전송한다`() {
+        client
+            .`when`(HttpRequest.request().withMethod("POST").withPath("/push/send"),
+                Times.exactly(1))
+            .respond(
+                HttpResponse.response()
+                    .withStatusCode(200)
+                    .withBody(ResponseTestFixture.GET_RECEIPT_OK_MULTIPLE_RESPONSE)
+            )
+
+        val expoPushNotification = PushNotification().apply {
+            to = listOf(EXPO_NOTIFICATION_TOKEN, EXPO_NOTIFICATION_TOKEN_2)
+            title = "title"
+            body = "content"
+        }
+
+
+        val tickets: List<TicketResponse.Ticket> =
+            testee.sendPushNotifications(listOf(expoPushNotification))
+
+
+        val ids: List<String> = tickets.map{ it.id }
+
+        val receipts: Map<String, ReceiptResponse.Receipt> =
+            testee.getPushNotificationReceipts(ids)
+
+        Assertions.assertThat(receipts).isNotNull
+    }
+
+    // 퀘스트 완료 알림을 진행한다.. 흠..
+
+}

--- a/src/test/kotlin/kr/or/dohands/dozon/notification/ResponseTextFixture.kt
+++ b/src/test/kotlin/kr/or/dohands/dozon/notification/ResponseTextFixture.kt
@@ -1,0 +1,77 @@
+package kr.or.dohands.dozon.notification
+
+object ResponseTestFixture {
+
+    const val RECEIPT_ID_1 = "645c0c84-1938-4dee-8c5f-b41076b0930c"
+
+    const val PUSH_SEND_OK_SINGLE_RESPONSE =
+        """
+          {
+              "data": [
+                  {
+                      "status": "ok",
+                       "id": "caa6fe6e-85d8-456c-bf57-e8cdc3fcb137"
+                  }
+              ]
+          }
+          """
+
+    const val GET_RECEIPT_OK_SINGLE_RESPONSE =
+        """
+          {
+              "data": {
+                  "caa6fe6e-85d8-456c-bf57-e8cdc3fcb137": {
+                      "status": "ok"
+                  }
+              }
+          }
+          """
+
+    const val RECEIPT_ID_2 = "0d44e896-1a04-4409-a56e-a7383641cdb7"
+
+    const val RECEIPT_ID_3 = "0d44e896-1a04-4409-a56e-a7383641cdb7"
+
+    const val PUSH_SEND_OK_MULTIPLE_RESPONSE =
+        """
+          {
+              "data":[
+                  {
+                      "status":"ok",
+                      "id":"0d44e896-1a04-4409-a56e-a7383641cdb7"
+                  },
+                  {
+                      "status":"ok",
+                      "id":"d6d93f26-a037-44a4-844d-c5c458844e9b"
+                  }
+              ]
+          }
+          """
+
+    const val GET_RECEIPT_OK_MULTIPLE_RESPONSE =
+        """
+          {
+              "data":{
+                  "0d44e896-1a04-4409-a56e-a7383641cdb7":{
+                      "status":"ok"
+                  },
+                  "d6d93f26-a037-44a4-844d-c5c458844e9b":{
+                      "status":"ok"
+                  }
+              }
+          }
+          """
+
+    const val PUSH_SEND_VALIDATION_ERROR_RESPONSE =
+        """
+          {
+              "errors":[
+                  {
+                      "code":"VALIDATION_ERROR",
+                      "message":"[0].data must be of type object.",
+                      "isTransient":false,
+                      "requestId":"96995d9b-1530-48ad-8501-7410acd9d2c6"
+                  }
+              ]
+          }
+          """
+}


### PR DESCRIPTION

[구성]

- ExpoPush알림 전용 클라이언트 클래스 생성
- MockServer 객체를 통해 테스트 진행
- 실제 기능에는 Mockserver를 제외하고 api 테스트를 진행 -> 기능에 이상없는 것을 확인

[고려할점]
- 푸시 알림 종류를 구분하는 파라미터 추가 필요
- pushToken 검색을 위한 대상자 User를 탐색하는 로직 구성 필요

- 사용하지 않는 클래스 추후 제거 예정
- 마감기간이 촉박해 예외처리를 통해서 현재 꼭 해결할 필요가 없는 에러는 ignore handling을 진행
